### PR TITLE
Add docstrings and CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ sap = Sapscript()
 - types_/
 - utils/
 - parallel/
+## KeyValue Clipboard Helper
+
+В файле `temp.py` находится простое приложение на Tkinter. Оно читает пары `ключ-значение` из `key_value_data.json` и копирует значения в буфер обмена. Запустить приложение можно командой:
+
+```bash
+python temp.py
+```
+
+Используйте сочетание `Ctrl+Shift+C` или иконку в трее, чтобы показать или скрыть окно.
+
 
 ## Лицензия
 MIT

--- a/element_finder.py
+++ b/element_finder.py
@@ -1,5 +1,6 @@
 # --- START OF FILE: pysapscript/element_finder.py ---
 # (This is a new file)
+"""Finds SAP GUI elements using label and position heuristics."""
 import win32com.client
 import logging
 import time

--- a/gui_tree.py
+++ b/gui_tree.py
@@ -1,4 +1,5 @@
 # Файл: sapscriptwizard/gui_tree.py
+"""Wrapper around the SAP GuiTree control"""
 import win32com.client
 from typing import List, Optional, Any, Tuple # Добавим Any для _com_object
 import time # Для возможных задержек

--- a/locator_helpers.py
+++ b/locator_helpers.py
@@ -1,3 +1,4 @@
+"""Helper dataclasses and functions for locating SAP GUI elements."""
 import math
 from typing import Optional, List, Tuple
 from dataclasses import dataclass, field

--- a/parallel/__init__.py
+++ b/parallel/__init__.py
@@ -1,2 +1,4 @@
+"""Helpers for launching and controlling SAP sessions in parallel."""
+
 from .runner import SapParallelRunner
 from .api import run_parallel

--- a/parallel/api.py
+++ b/parallel/api.py
@@ -1,4 +1,5 @@
 # File: pysapscript/parallel/api.py
+"""Public API helpers for running SAP tasks in parallel."""
 
 import logging
 import sys

--- a/parallel/runner.py
+++ b/parallel/runner.py
@@ -1,4 +1,5 @@
 # File: pysapscript/parallel/runner.py
+"""Worker process used by run_parallel to drive SAP sessions."""
 
 import multiprocessing
 import time

--- a/pysapscript.py
+++ b/pysapscript.py
@@ -1,1 +1,1 @@
-
+"""Placeholder module for future SAP script helpers."""

--- a/sapscriptwizard.py
+++ b/sapscriptwizard.py
@@ -1,4 +1,5 @@
 # File: sapscriptwizard/sapscriptwizard.py
+"""High level interface to the SAP GUI scripting COM API."""
 
 import time
 import atexit

--- a/shell_table.py
+++ b/shell_table.py
@@ -1,3 +1,4 @@
+"""Abstraction over SAP shell tables (ALV grid)"""
 from typing import Self, Any, ClassVar, overload, Union, Dict, List # Добавлено Union
 # --- НОВЫЙ КОД ---
 from pathlib import Path # Добавлено для to_csv

--- a/temp.py
+++ b/temp.py
@@ -1,5 +1,9 @@
 # === Казахстан BEGIN ========================================================
 # Main clipboard helper application with tray icon and hotkey
+"""
+Small Tkinter clipboard helper that maps keys to values.
+Run `python temp.py` to launch the GUI, then use Ctrl+Shift+C to show or hide the window.
+"""
 
 import tkinter as tk
 import tkinter.messagebox as messagebox
@@ -12,6 +16,10 @@ import sys
 import os
 
 class KeyValueApp:
+    """Clipboard helper with tray icon.
+    Buttons copy values from ``key_value_data.json`` to the clipboard.
+    Start the application with ``python temp.py``.
+    """
     def __init__(self, root):
         self.root = root
         self.root.title("Key/Value Clipboard Helper")

--- a/types_/types.py
+++ b/types_/types.py
@@ -1,3 +1,4 @@
+"""Typed enums and data structures for the project."""
 from enum import Enum
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,3 @@
+"""Utility helpers for reading SAP configuration files."""
+
 from .sap_config import SapLogonConfig

--- a/utils/sap_config.py
+++ b/utils/sap_config.py
@@ -1,4 +1,5 @@
 # --- НОВЫЙ ФАЙЛ: pysapscript\utils\sap_config.py ---
+"""Utilities for reading saplogon.ini configuration files."""
 import configparser
 import os
 from pathlib import Path

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,3 +1,4 @@
+"""General utility functions used across the project."""
 import os
 import time
 

--- a/window.py
+++ b/window.py
@@ -1,3 +1,4 @@
+"""High level wrapper around a SAP GUI window."""
 import pprint # Для dump_element_state
 import json
 import time


### PR DESCRIPTION
## Summary
- document module purpose across scripts
- explain KeyValueApp usage in README
- add class and module docstrings in `temp.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68432e029a0c8320ae432e53969b7dc4